### PR TITLE
fix(starter): use relative paths for audio and texture assets to support non-root deployments

### DIFF
--- a/packages/starter-assets/starter-template/src/index.template.ts
+++ b/packages/starter-assets/starter-template/src/index.template.ts
@@ -38,12 +38,12 @@ import { RobotSystem } from './robot.js';
 
 const assets: AssetManifest = {
   chimeSound: {
-    url: '/audio/chime.mp3',
+    url: './audio/chime.mp3',
     type: AssetType.Audio,
     priority: 'background',
   },
   webxr: {
-    url: '/textures/webxr.png',
+    url: './textures/webxr.png',
     type: AssetType.Texture,
     priority: 'critical',
   },


### PR DESCRIPTION
## Summary

Fixes #40 and closes #44.

The starter template generated by `npm create @iwsdk@latest` uses **absolute paths** for two assets:

```ts
// Before (broken on GitHub Pages / non-root base)
chimeSound: { url: '/audio/chime.mp3', ... }
webxr:      { url: '/textures/webxr.png', ... }
```

When deployed to any subdirectory (e.g. GitHub Pages at `username.github.io/my-project/`), these resolve to `/audio/chime.mp3` — missing the base path — and return a **404**. The "Enter XR" experience silently breaks because the critical `webxr.png` texture never loads.

Interestingly, the GLTF assets in the same file already use the correct `./` relative form:

```ts
environmentDesk: { url: './gltf/environmentDesk/environmentDesk.gltf', ... }
```

This fix brings `chime.mp3` and `webxr.png` in line with the same pattern.

## Changes

**`packages/starter-assets/starter-template/src/index.template.ts`**

```diff
- url: '/audio/chime.mp3',
+ url: './audio/chime.mp3',

- url: '/textures/webxr.png',
+ url: './textures/webxr.png',
```

That's the entire change — 2 lines, zero risk of regression on local `dev` usage, and it immediately unblocks GitHub Pages deployments for every new user.

## Testing

- [x] Verified the fix resolves 404s when serving from a subdirectory
- [x] Consistent with existing GLTF asset path style in the same file
- [x] No changes to runtime behavior for root-based deployments (`/` base)

## Impact

This affects **every first-time user** who follows the Get Started guide and tries to share their experience via GitHub Pages. It's a high-visibility, low-risk fix that significantly improves the onboarding experience.