### PR TITLE
fix(create): dedupe uikit/three in starter Vite scaffold

### DIFF
--- a/packages/create/src/project-files.ts
+++ b/packages/create/src/project-files.ts
@@ -106,6 +106,11 @@ function createProjectPackageJson(
     },
     dependencies: {
       '@iwsdk/core': packageSpec('@iwsdk/core'),
+      // Declared so Vite resolve.dedupe / optimizeDeps.include can resolve from
+      // the app root under pnpm (transitive-only installs break `vite build`).
+      '@pmndrs/uikit': '^1.0.74',
+      '@pmndrs/uikit-horizon': '^1.0.74',
+      '@pmndrs/uikit-lucide': '^1.0.74',
       three: 'npm:super-three@0.181.0',
     },
     devDependencies: {
@@ -118,7 +123,15 @@ function createProjectPackageJson(
         : {}),
       vite: '^7.1.4',
     },
-    overrides: { sharp: '0.35.3' },
+    overrides: {
+      sharp: '0.35.3',
+      three: 'npm:super-three@0.181.0',
+    },
+    pnpm: {
+      overrides: {
+        three: 'npm:super-three@0.181.0',
+      },
+    },
     engines: {
       node: '>=20.19.0 <21.0.0-0 || >=22.12.0 <23.0.0-0 || >=24.0.0',
     },

--- a/packages/create/template/common/vite.config.ts
+++ b/packages/create/template/common/vite.config.ts
@@ -18,8 +18,25 @@ export default defineConfig({
     rollupOptions: { input: './index.html' },
   },
   esbuild: { target: 'esnext' },
+  // @drawcall/uikitml otherwise pulls a second three/@pmndrs/uikit graph
+  // (three@0.185 vs app super-three@0.181). Duplicate Component classes break
+  // instanceof checks → "Only pmndrs/uikit components can be added as children".
+  resolve: {
+    dedupe: [
+      'three',
+      '@pmndrs/uikit',
+      '@pmndrs/uikit-horizon',
+      '@pmndrs/uikit-lucide',
+    ],
+  },
   optimizeDeps: {
     exclude: ['@babylonjs/havok'],
+    include: [
+      '@pmndrs/uikit',
+      '@pmndrs/uikit-horizon',
+      '@pmndrs/uikit-lucide',
+      '@drawcall/uikitml',
+    ],
     esbuildOptions: { target: 'esnext' },
   },
   publicDir: 'public',

--- a/packages/create/tests/project-files.test.ts
+++ b/packages/create/tests/project-files.test.ts
@@ -74,6 +74,11 @@ describe('common starter project files', () => {
         .spatialUI,
     ).toEqual({ kit: 'horizon' });
     expect(textFile(outputs[0], 'vite.config.ts')).toContain('iwsdkDev()');
+    expect(textFile(outputs[0], 'vite.config.ts')).toContain('dedupe:');
+    expect(textFile(outputs[0], 'vite.config.ts')).toContain('@pmndrs/uikit');
+    expect(textFile(outputs[0], 'vite.config.ts')).toContain(
+      '@drawcall/uikitml',
+    );
     expect(textFile(outputs[0], 'src/assets.ts')).toContain(
       'VITE_IWSDK_EXAMPLE_ASSET_BASE_URL',
     );
@@ -135,13 +140,25 @@ describe('common starter project files', () => {
     expect(files.some((file) => file.path === '.gitignore')).toBe(true);
     expect(files.some((file) => file.path === '.nvmrc')).toBe(true);
     expect(packageJson.dependencies['@iwsdk/core']).toMatch(/^\d+\.\d+\.\d+/u);
+    expect(packageJson.dependencies['@pmndrs/uikit']).toBe('^1.0.74');
+    expect(packageJson.dependencies['@pmndrs/uikit-horizon']).toBe('^1.0.74');
+    expect(packageJson.dependencies['@pmndrs/uikit-lucide']).toBe('^1.0.74');
+    expect(packageJson.dependencies.three).toBe('npm:super-three@0.181.0');
     expect(
       packageJson.devDependencies['@iwsdk/example-assets'],
     ).toBeUndefined();
     expect(packageJson.devDependencies['@meta-quest/metavr']).toBe('^1.3.2');
     expect(packageJson.devDependencies['@meta-quest/hzdb']).toBeUndefined();
     expect(packageJson.devDependencies['@types/three']).toBe('^0.181.0');
-    expect(packageJson.overrides).toEqual({ sharp: '0.35.3' });
+    expect(packageJson.overrides).toEqual({
+      sharp: '0.35.3',
+      three: 'npm:super-three@0.181.0',
+    });
+    expect(packageJson.pnpm).toEqual({
+      overrides: {
+        three: 'npm:super-three@0.181.0',
+      },
+    });
     expect(packageJson.scripts.typecheck).toBe('tsc --noEmit');
     expect(JSON.stringify(packageJson)).not.toContain('@latest');
     expect(JSON.stringify(packageJson)).not.toContain('@pmndrs/chef');


### PR DESCRIPTION
## Summary
- Fresh `create @iwsdk` apps crash loading the welcome UIKitML panel because Vite embeds two `@pmndrs/uikit` graphs (app `super-three@0.181` vs `@drawcall/uikitml`'s `three@0.185`).
- Dedupe `three` / `@pmndrs/uikit*` in the scaffold Vite config and force a single `three` resolution via npm/pnpm overrides so Horizon kit components and HTML `div` containers share one Component class.
- Declare `@pmndrs/uikit`, `@pmndrs/uikit-horizon`, and `@pmndrs/uikit-lucide` as direct dependencies so Vite `resolve.dedupe` / `optimizeDeps.include` can resolve them from the app root under pnpm (transitive-only installs break `vite build` on clean CI/Vercel).

Supersedes #49.

## Test plan
- [ ] `pnpm create @iwsdk@latest` (or local create from this branch) into a clean directory
- [ ] `pnpm install && pnpm dev`
- [ ] Confirm no browser error: `Only pmndrs/uikit components can be added as children`
- [ ] Welcome panel renders with heading, divider, Enter XR button
- [ ] `rm -rf node_modules/.vite && pnpm install` still produces a single uikit peer graph (no both `three@0.185.1` and `super-three@0.181.0` uikit builds in Vite deps)
- [ ] From a clean install (no pre-existing root `node_modules/@pmndrs`), `pnpm run build` succeeds


Made with [Cursor](https://cursor.com)